### PR TITLE
Separate driver

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -56,13 +56,13 @@ Optional
 * `Py2neo Python package <https://pypi.org/project/py2neo/>`_
    Alternative Neo4j driver that provides http or bolt connections.
    Transfers are 2X faster, but the memory requirements can be excessive for large transfers.
-   This can be selected via the driver parameter in the connector.
+   This can be selected via the driver parameter in the Trovares Neo4jDriver class.
 * `Neo4j-arrow plugin and Python package <https://github.com/neo4j-field/neo4j-arrow>`_
    Alternative driver for transfers that is very experimental.
    This requires GDS and the jar plugin found in the above link to be installed as part of Neo4j.
    In addition it requires the neo4j-arrow python package found in the above link.
    At the moment, this provides very fast transfer speeds, but is limited to only int and string data types (Nulls do not work for these types).
-   This can be selected via the driver parameter in the connector.
+   This can be selected via the driver parameter in the Trovares Neo4jDriver class.
 
 Installation
 ------------
@@ -99,11 +99,12 @@ All of these data frames are created in Trovares xGT and then all of the data is
 .. code-block:: python
 
    import xgt
-   from trovares_connector import Neo4jConnector
+   from trovares_connector import Neo4jConnector, Neo4jDriver
 
    xgt_server = xgt.Connection()
    xgt_server.set_default_namespace('neo4j')
-   conn = Neo4jConnector(xgt_server, neo4j_auth=('neo4j', 'foo'))
+   neo4j_server = Neo4jDriver(auth=('neo4j', 'foo'))
+   conn = Neo4jConnector(xgt_server, neo4j_server)
 
    conn.transfer_to_xgt(vertices=conn.neo4j_node_labels,
                         edges=conn.neo4j_relationship_types)
@@ -118,15 +119,31 @@ Using this idiom requires knowing some schema information about the graph data s
 .. code-block:: python
 
    import xgt
-   from trovares_connector import Neo4jConnector
+   from trovares_connector import Neo4jConnector, Neo4jDriver
 
    xgt_server = xgt.Connection()
    xgt_server.set_default_namespace('neo4j')
-   conn = Neo4jConnector(xgt_server, neo4j_auth=('neo4j', 'foo'))
+   neo4j_server = Neo4jDriver(auth=('neo4j', 'foo'))
+   conn = Neo4jConnector(xgt_server, neo4j_server)
 
    nodes_to_copy = ['Person']
    edges_to_copy = ['KNOWS']
    conn.transfer_to_xgt(vertices=nodes_to_copy, edges=edges_to_copy)
+
+Using with the neo4j.Neo4jDriver
+--------------------------------
+
+.. code-block:: python
+
+   import xgt
+   from trovares_connector import Neo4jConnector
+   from neo4j import GraphDatabase
+
+   xgt_server = xgt.Connection()
+   xgt_server.set_default_namespace('neo4j')
+   neo4j_driver = GraphDatabase.driver("bolt://localhost", auth=('neo4j', 'foo'))
+   conn = Neo4jConnector(xgt_server, neo4j_driver)
+   different_database_conn = Neo4jConnector(xgt_server, (neo4j_driver, "my_database"))
 
 Additional Examples
 -------------------

--- a/examples/example.py
+++ b/examples/example.py
@@ -24,8 +24,8 @@ import xgt
 xgt_server = xgt.Connection()
 xgt_server.set_default_namespace('neo4j')
 
-neo4j_driver=Neo4jDriver(auth=('neo4j', 'foo'))
-c=Neo4jConnector(xgt_server, neo4j_driver)
+neo4j_driver = Neo4jDriver(auth=('neo4j', 'foo'))
+c = Neo4jConnector(xgt_server, neo4j_driver)
 
 nodes_to_copy = [
     'Forum',

--- a/examples/example.py
+++ b/examples/example.py
@@ -18,13 +18,14 @@
 #===----------------------------------------------------------------------===#
 
 from pprint import pprint
-from trovares_connector import Neo4jConnector
+from trovares_connector import Neo4jConnector, Neo4jDriver
 import xgt
 
 xgt_server = xgt.Connection()
 xgt_server.set_default_namespace('neo4j')
 
-c=Neo4jConnector(xgt_server, neo4j_auth=('neo4j', 'foo'))
+neo4j_driver=Neo4jDriver(auth=('neo4j', 'foo'))
+c=Neo4jConnector(xgt_server, neo4j_driver)
 
 nodes_to_copy = [
     'Forum',

--- a/examples/match.py
+++ b/examples/match.py
@@ -20,23 +20,24 @@
 # This example creates a graph in Neo4j, transfers it to xGT, and
 # runs the same query in xGT in Neo4j.
 
-from trovares_connector import Neo4jConnector
+from trovares_connector import Neo4jConnector, Neo4jDriver
 import xgt
 
 xgt_server = xgt.Connection()
 xgt_server.set_default_namespace('neo4j')
 database = "test"
 
-c=Neo4jConnector(xgt_server, neo4j_auth=('neo4j', 'foo'), neo4j_database=database)
+neo4j_driver=Neo4jDriver(auth=('neo4j', 'foo'), database=database)
+c=Neo4jConnector(xgt_server, neo4j_driver)
 
 # Uncomment to delete the database
 """
-with c.neo4j_driver.session(database=database) as session:
+with neo4j_driver.bolt.session(database=database) as session:
     session.run("MATCH (n) DETACH DELETE n")
 """
 
 # Create a chain with with a loop in Neo4j
-with c.neo4j_driver.session(database=database) as session:
+with neo4j_driver.bolt.session(database=database) as session:
     end = 10
     session.run('create (a:Person{id:0})')
     for i in range(0, end):
@@ -50,7 +51,7 @@ c.transfer_to_xgt(edges=["Knows"])
 query = "match(a)-->()-->()-->(a) return a.id"
 
 # Get results with Neo4j
-with c.neo4j_driver.session(database=database) as session:
+with neo4j_driver.bolt.session(database=database) as session:
     job = session.run(query)
     print("Neo4j found the following nodes in a triangle: " + ','.join(str(row[0]) for row in job))
 

--- a/examples/metadata.py
+++ b/examples/metadata.py
@@ -25,8 +25,8 @@ import xgt
 xgt_server = xgt.Connection()
 xgt_server.set_default_namespace('neo4j')
 
-neo4j_driver=GraphDatabase.driver("bolt://localhost", auth=('neo4j', 'foo'))
-c=Neo4jConnector(xgt_server, neo4j_driver)
+neo4j_driver = GraphDatabase.driver("bolt://localhost", auth=('neo4j', 'foo'))
+c = Neo4jConnector(xgt_server, neo4j_driver)
 
 def show(label, values):
     print("\n========> " + label)

--- a/examples/metadata.py
+++ b/examples/metadata.py
@@ -19,12 +19,14 @@
 
 from pprint import pprint
 from trovares_connector import Neo4jConnector
+from neo4j import GraphDatabase
 import xgt
 
 xgt_server = xgt.Connection()
 xgt_server.set_default_namespace('neo4j')
 
-c=Neo4jConnector(xgt_server, neo4j_auth=('neo4j', 'foo'))
+neo4j_driver=GraphDatabase.driver("bolt://localhost", auth=('neo4j', 'foo'))
+c=Neo4jConnector(xgt_server, neo4j_driver)
 
 def show(label, values):
     print("\n========> " + label)

--- a/examples/trovares_to_neo4j.py
+++ b/examples/trovares_to_neo4j.py
@@ -20,18 +20,19 @@
 # This example just creates a graph in xGT, transfers it to Neo4j, and
 # runs the same query in xGT in Neo4j.
 
-from trovares_connector import Neo4jConnector
+from trovares_connector import Neo4jConnector, Neo4jDriver
 import xgt
 
 xgt_server = xgt.Connection()
 xgt_server.set_default_namespace('neo4j')
 database = "test"
 
-c=Neo4jConnector(xgt_server, neo4j_auth=('neo4j', 'foo'), neo4j_database=database)
+neo4j_driver=Neo4jDriver(auth=('neo4j', 'foo'), database=database)
+c=Neo4jConnector(xgt_server, neo4j_driver)
 
 # Uncomment to delete the database
 """
-with c.neo4j_driver.session(database=database) as session:
+with neo4j_driver.bolt.session(database=database) as session:
     session.run("MATCH (n) DETACH DELETE n")
 """
 
@@ -53,7 +54,7 @@ c.transfer_to_neo4j(edges=["Knows"], vertex_keys=True)
 query = "match(a)-->()-->()-->(a) return a.id"
 
 # Get results with Neo4j
-with c.neo4j_driver.session(database=database) as session:
+with neo4j_driver.bolt.session(database=database) as session:
     job = session.run(query)
     print("Neo4j found the following nodes in a triangle: " + ','.join(str(row[0]) for row in job))
 

--- a/examples/trovares_to_neo4j.py
+++ b/examples/trovares_to_neo4j.py
@@ -27,13 +27,12 @@ xgt_server = xgt.Connection()
 xgt_server.set_default_namespace('neo4j')
 database = "test"
 
-neo4j_driver=Neo4jDriver(auth=('neo4j', 'foo'), database=database)
-c=Neo4jConnector(xgt_server, neo4j_driver)
+neo4j_driver = Neo4jDriver(auth=('neo4j', 'foo'), database=database, driver="py2neo-bolt")
+c = Neo4jConnector(xgt_server, neo4j_driver)
 
 # Uncomment to delete the database
 """
-with neo4j_driver.bolt.session(database=database) as session:
-    session.run("MATCH (n) DETACH DELETE n")
+neo4j_driver.query("MATCH (n) DETACH DELETE n").finalize()
 """
 
 xgt_server.drop_frame("Knows")
@@ -54,9 +53,8 @@ c.transfer_to_neo4j(edges=["Knows"], vertex_keys=True)
 query = "match(a)-->()-->()-->(a) return a.id"
 
 # Get results with Neo4j
-with neo4j_driver.bolt.session(database=database) as session:
-    job = session.run(query)
-    print("Neo4j found the following nodes in a triangle: " + ','.join(str(row[0]) for row in job))
+with neo4j_driver.query(query, write=False) as job:
+    print("Neo4j found the following nodes in a triangle: " + ','.join(str(row[0]) for row in job.result()))
 
 # Get results with xGT
 job = xgt_server.run_job(query)

--- a/jupyter/hello_world.ipynb
+++ b/jupyter/hello_world.ipynb
@@ -22,14 +22,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from trovares_connector import Neo4jConnector\n",
+    "from trovares_connector import Neo4jConnector, Neo4jDriver\n",
     "import xgt\n",
     "\n",
     "xgt_server = xgt.Connection()\n",
     "xgt_server.set_default_namespace('neo4j')\n",
     "database = \"test\"\n",
+    "neo4j_server = Neo4jDriver(auth=('neo4j', 'foo'), database=database)\n",
     "\n",
-    "c=Neo4jConnector(xgt_server, neo4j_auth=('neo4j', 'foo'), neo4j_database=database)"
+    "c=Neo4jConnector(xgt_server, neo4j_server)"
    ]
   },
   {
@@ -39,8 +40,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with c.neo4j_driver.session(database=database) as session:\n",
-    "    session.run(\"MATCH (n) DETACH DELETE n\")"
+    "neo4j_server.query(\"MATCH (n) DETACH DELETE n\").finalize()"
    ]
   },
   {
@@ -58,12 +58,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "with c.neo4j_driver.session(database=database) as session:\n",
-    "    names = [\"Nicole\", \"Nathan\", \"Bishop\", \"Ashley\", \"Joe\"]\n",
-    "    session.run(f'create (a:Person{{id:0, name:\"{names[0]}\"}})')\n",
-    "    for i in range(0, len(names) - 1):\n",
-    "        session.run(f'match(a:Person) where a.id = {i} create (a)-[:Knows]->(:Person{{id:{i + 1},name:\"{names[i + 1]}\"}})')\n",
-    "    session.run('match(a:Person), (b:Person) where a.id = 2 and b.id = 0 create (a)-[:Knows]->(b)')"
+    "names = [\"Nicole\", \"Nathan\", \"Bishop\", \"Ashley\", \"Joe\"]\n",
+    "neo4j_server.query(f'create (a:Person{{id:0, name:\"{names[0]}\"}})').finalize()\n",
+    "for i in range(0, len(names) - 1):\n",
+    "    neo4j_server.query(f'match(a:Person) where a.id = {i} create (a)-[:Knows]->(:Person{{id:{i + 1},name:\"{names[i + 1]}\"}})').finalize()\n",
+    "neo4j_server.query('match(a:Person), (b:Person) where a.id = 2 and b.id = 0 create (a)-[:Knows]->(b)').finalize()"
    ]
   },
   {
@@ -500,7 +499,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/jupyter/temporal_triangles.ipynb
+++ b/jupyter/temporal_triangles.ipynb
@@ -41,7 +41,7 @@
     "xgt_server.set_default_namespace('neo4j')\n",
     "database = \"temporal-triangles-1M\"\n",
     "neo4j_server = Neo4jDriver(auth=('neo4j', 'foo'), database=database)\n",
-    "c=Neo4jConnector(xgt_server, neo4j_server)"
+    "c = Neo4jConnector(xgt_server, neo4j_server)"
    ]
   },
   {
@@ -126,9 +126,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "[[26563, 7598, 51565, 7598, 15727, 7612, 14]]\n",
       "Query to xgt time: 0.49\n",
-      "Total xgt time including transfer: 35.35\n",
-      "[[26563, 7598, 51565, 7598, 15727, 7612, 14]]\n"
+      "Total xgt time including transfer: 35.35\n"
      ]
     }
    ],
@@ -159,15 +159,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Neo4j query time: 45.05\n",
-      "<Record v1id=26563 e1_timestamp=7598 v2id=51565 e2_timestamp=7598 v3id=15727 e3_timestamp=7612 delta=14>\n"
+      "<Record v1id=26563 e1_timestamp=7598 v2id=51565 e2_timestamp=7598 v3id=15727 e3_timestamp=7612 delta=14>\n",
+      "Neo4j query time: 45.05\n"
      ]
     }
    ],
    "source": [
     "t0 = time.time()\n",
-    "with neo4j_server.query(query) as result:\n",
-    "    for row in result:\n",
+    "with neo4j_server.query(query) as job:\n",
+    "    for row in job.result():\n",
     "        print(row)\n",
     "    n_duration = time.time() - t0\n",
     "    print(f\"Neo4j query time: {n_duration:,.2f}\")"

--- a/jupyter/temporal_triangles.ipynb
+++ b/jupyter/temporal_triangles.ipynb
@@ -17,7 +17,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from trovares_connector import Neo4jConnector\n",
+    "from trovares_connector import Neo4jConnector, Neo4jDriver\n",
     "import xgt\n",
     "import time"
    ]
@@ -39,8 +39,9 @@
    "source": [
     "xgt_server = xgt.Connection()\n",
     "xgt_server.set_default_namespace('neo4j')\n",
-    "database=\"temporal-triangles-1M\"\n",
-    "c=Neo4jConnector(xgt_server, neo4j_auth=('neo4j', 'foo'), neo4j_database=database)"
+    "database = \"temporal-triangles-1M\"\n",
+    "neo4j_server = Neo4jDriver(auth=('neo4j', 'foo'), database=database)\n",
+    "c=Neo4jConnector(xgt_server, neo4j_server)"
    ]
   },
   {
@@ -135,9 +136,9 @@
     "t0 = time.time()\n",
     "job = xgt_server.run_job(query)\n",
     "q_duration = time.time() - t0\n",
+    "print(job.get_data())\n",
     "print(f\"Query to xgt time: {q_duration:,.2f}\")\n",
-    "print(f\"Total xgt time including transfer: {t_duration + q_duration:,.2f}\")\n",
-    "print(job.get_data())"
+    "print(f\"Total xgt time including transfer: {t_duration + q_duration:,.2f}\")"
    ]
   },
   {
@@ -164,13 +165,12 @@
     }
    ],
    "source": [
-    "with c.neo4j_driver.session(database=database) as session:\n",
-    "    t0 = time.time()\n",
-    "    result = session.run(query)\n",
-    "    n_duration = time.time() - t0\n",
-    "    print(f\"Neo4j query time: {n_duration:,.2f}\")\n",
+    "t0 = time.time()\n",
+    "with neo4j_server.query(query) as result:\n",
     "    for row in result:\n",
-    "        print(row)"
+    "        print(row)\n",
+    "    n_duration = time.time() - t0\n",
+    "    print(f\"Neo4j query time: {n_duration:,.2f}\")"
    ]
   },
   {
@@ -210,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.5"
   }
  },
  "nbformat": 4,

--- a/src/trovares_connector/__init__.py
+++ b/src/trovares_connector/__init__.py
@@ -18,6 +18,8 @@
 
 __ALL__ = [
   'Neo4jConnector',
+  'Neo4jDriver',
 ]
 
 from .trovares_connector import Neo4jConnector
+from .trovares_connector import Neo4jDriver

--- a/src/trovares_connector/trovares_connector.py
+++ b/src/trovares_connector/trovares_connector.py
@@ -26,6 +26,150 @@ import xgt
 import os
 import time
 
+class Neo4jDriver(object):
+    def __init__(self, host = 'localhost',
+                       bolt_port = 7687, http_port = 7474,
+                       arrow_port = 9999, auth = None,
+                       database = neo4j.DEFAULT_DATABASE,
+                       driver = 'neo4j-bolt',
+                       protocol = 'neo4j',
+                       http_protocol = 'http',
+                       verbose = False):
+        """
+        Initializes the driver class.
+
+        Parameters
+        ----------
+        host : str
+            Host address of the Neo4j server.
+        bolt_port : int
+            Bolt port of the Neo4j server.
+        http_port : int
+            HTTP port of the Neo4j server.
+            Used with HTTP drivers.
+        arrow_port : int
+            Arrow port of the Neo4j server.
+            Used with Arrow driver.
+        auth : neo4j.Auth
+            Authentication details.
+        database : str
+            Neo4j database to connect to.
+        driver : str
+            Driver to use for transferring data from Neo4j.
+            Options include 'neo4j-bolt', 'py2neo-bolt', 'py2neo-http', and 'neo4j-arrow'.
+            Some connections, such as schema querying will still go through 'neo4j-bolt',
+            but all data transferring will use the method selected here.
+            'neo4j-arrow' is considered very experimental.
+            See the documentation for requirements for using.
+        protocol : str
+            Protocol used when connecting to Neo4j through bolt.
+            Acceptable values include: neo4j, neo4j+s, neo4j+ssc, bolt, bolt+s, and bolt+ssc.
+        http_protocol : str
+            Protocol used when connecting to Neo4j through http with http drivers.
+            Acceptable values include: http, https, http+s, http+ssc.
+        verbose : bool
+            Print detailed information during calls.
+        """
+        if not isinstance(host, (neo4j.Neo4jDriver, neo4j.BoltDriver)):
+            self._host = host
+            self._bolt_port = bolt_port
+            self._http_port = http_port
+            self._arrow_port = arrow_port
+            self._auth = auth
+            self._protocol = protocol
+            self._http_protocol = http_protocol
+            # neo4j arrow can't take none as a parameter for the database.
+            self._database_arrow = 'neo4j' if database == None else database
+            driver_passed_in = False
+        else:
+            driver_passed_in = True
+
+        self._database = database
+        self.__verbose = verbose
+
+        # These are just kept as seperate variables because they may be needed
+        self._neo4j_driver = None
+        self._py2neo_driver = None
+        self._arrow_driver = None
+
+        if self.__verbose:
+            print('Using ' + driver + ' for transfers of data.')
+
+        if driver_passed_in:
+            self._neo4j_driver = host
+        else:
+            self._neo4j_driver = neo4j.GraphDatabase.driver(f"{self._protocol}://{self._host}",
+                                                            auth=self._auth)
+        if driver == 'neo4j-bolt':
+            pass
+        elif driver == 'py2neo-bolt':
+            from py2neo import Graph
+            self._py2neo_driver = Graph(
+                self._protocol + "://" + self._host + ":" +str(neo4j_bolt_port),
+                auth=auth, name=neo4j_database)
+        elif driver == 'py2neo-http':
+            from py2neo import Graph
+            self._py2neo_driver = Graph(
+                self._http_protocol + "://" + self._host + ":" +str(neo4j_http_port),
+                auth=auth, name=neo4j_database)
+        elif driver == 'neo4j-arrow':
+            import neo4j_arrow as na
+            self._arrow_driver = na.Neo4jArrow(self._auth[0],
+                                               self._auth[1])
+        else:
+            raise ValueError(f"Unknown driver, {driver}.")
+
+    @classmethod
+    def from_Neo4jDriver(self, neo4j_driver,
+                         database = neo4j.DEFAULT_DATABASE):
+        return Neo4jDriver(neo4j_driver, database = database)
+
+    @property
+    def bolt(self) -> neo4j.Neo4jDriver:
+        """
+        Retrieve the Python bolt driver connected to the Neo4j database.
+
+        Returns
+        -------
+        neo4j.Neo4jDriver
+          The Python bolt driver object that is connected to the Neo4j database.
+        """
+        return self._neo4j_driver
+
+    def query(self, query, use_neo4j_always = False):
+        if not use_neo4j_always and self._py2neo_driver is not None:
+            return self.py2neo_run_closure(self, query)
+        else:
+            return self.neo4j_run_closure(self, query)
+
+    class py2neo_run_closure():
+        def __init__(self, connector, query):
+            self._result = connector._py2neo_driver.query(query)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type,exc_value, exc_traceback):
+            pass
+
+        def result(self):
+            return self._result
+
+    class neo4j_run_closure():
+        def __init__(self, connector, query):
+            self._query = query
+            self._connector = connector
+
+        def __enter__(self):
+            self._session = self._connector._neo4j_driver.session(database=self._connector._database,
+                                                                  default_access_mode=neo4j.READ_ACCESS)
+            return self
+        def __exit__(self, exc_type,exc_value, exc_traceback):
+            self._session.close()
+
+        def result(self):
+            return self._session.run(self._query)
+
 class Neo4jConnector(object):
     _NEO4J_TYPE_TO_XGT_TYPE = {
         'INTEGER': xgt.INT,
@@ -60,14 +204,9 @@ class Neo4jConnector(object):
     }
 
     def __init__(self, xgt_server,
-                       neo4j_host = 'localhost',
-                       neo4j_bolt_port = 7687, neo4j_http_port = 7474,
-                       neo4j_arrow_port = 9999, neo4j_auth = None,
-                       neo4j_database = neo4j.DEFAULT_DATABASE,
-                       verbose = False, disable_apoc = False,
-                       driver = 'neo4j-bolt',
-                       neo4j_protocol = 'neo4j',
-                       neo4j_http_protocol = 'http'):
+                       neo4j_driver,
+                       verbose = False,
+                       disable_apoc = False):
         """
         Initializes the connector class.
 
@@ -75,82 +214,24 @@ class Neo4jConnector(object):
         ----------
         xgt_server : xgt.Connection
             Connection object to xGT.
-        neo4j_host : str
-            Host address of the Neo4j server.
-        neo4j_bolt_port : int
-            Bolt port of the Neo4j server.
-        neo4j_http_port : int
-            HTTP port of the Neo4j server.
-            Used with HTTP drivers.
-        neo4j_arrow_port : int
-            Arrow port of the Neo4j server.
-            Used with Arrow driver.
-        neo4j_auth : neo4j.Auth
-            Authentication details.
-        neo4j_database : str
-            Neo4j database to connect to.
+        neo4j_driver : neo4j.Neo4jDriver, neo4j.BoltDriver, tuple(neo4j.Neo4jDriver, database), tuple(neo4j.BoltDriver, database), or trovares_connector.Neo4jDriver
+            Connection object to Neo4j.
         verbose : bool
             Print detailed information during calls.
         disable_apoc : bool
             If the connector finds APOC, it will use that to improve schema queries.
             If set to True this disables that feature.
-        driver : str
-            Driver to use for transferring data from Neo4j.
-            Options include 'neo4j-bolt', 'py2neo-bolt', 'py2neo-http', and 'neo4j-arrow'.
-            Some connections, such as schema querying will still go through 'neo4j-bolt',
-            but all data transferring will use the method selected here.
-            'neo4j-arrow' is considered very experimental.
-            See the documentation for requirements for using.
-        neo4j_protocol : str
-            Protocol used when connecting to Neo4j through bolt.
-            Acceptable values include: neo4j, neo4j+s, neo4j+ssc, bolt, bolt+s, and bolt+ssc.
-        neo4j_http_protocol : str
-            Protocol used when connecting to Neo4j through http with http drivers.
-            Acceptable values include: http, https, http+s, http+ssc.
         """
 
         self._xgt_server = xgt_server
-        self._neo4j_host = neo4j_host
-        self._neo4j_bolt_port = neo4j_bolt_port
-        self._neo4j_http_port = neo4j_http_port
-        self._neo4j_arrow_port = neo4j_arrow_port
-        self._neo4j_auth = neo4j_auth
-        self._neo4j_database = neo4j_database
-        self._neo4j_protocol = neo4j_protocol
-        self._neo4j_http_protocol = neo4j_http_protocol
-        # neo4j arrow can't take none as a parameter for the database.
-        self._neo4j_database_arrow = 'neo4j' if neo4j_database == None else neo4j_database
-        self.__verbose = verbose
-
-        self._default_namespace = xgt_server.get_default_namespace()
-        # These are just kept as seperate variables because they may be needed
-        self._neo4j_driver = None
-        self._py2neo_driver = None
-        self._arrow_driver = None
-
-        if self.__verbose:
-            print('Using ' + driver + ' for transfers of data.')
-
-        self._neo4j_driver = neo4j.GraphDatabase.driver(f"{self._neo4j_protocol}://{self._neo4j_host}",
-                                                        auth=self._neo4j_auth)
-        if driver == 'neo4j-bolt':
-            pass
-        elif driver == 'py2neo-bolt':
-            from py2neo import Graph
-            self._py2neo_driver = Graph(
-                self._neo4j_protocol + "://" + self._neo4j_host + ":" +str(neo4j_bolt_port),
-                auth=neo4j_auth, name=neo4j_database)
-        elif driver == 'py2neo-http':
-            from py2neo import Graph
-            self._py2neo_driver = Graph(
-                self._neo4j_http_protocol + "://" + self._neo4j_host + ":" +str(neo4j_http_port),
-                auth=neo4j_auth, name=neo4j_database)
-        elif driver == 'neo4j-arrow':
-            import neo4j_arrow as na
-            self._arrow_driver = na.Neo4jArrow(self._neo4j_auth[0],
-                                               self._neo4j_auth[1])
+        if isinstance(neo4j_driver, (neo4j.Neo4jDriver, neo4j.BoltDriver)):
+            self._neo4j_driver = Neo4jDriver.from_Neo4jDriver(neo4j_driver)
+        elif isinstance(neo4j_driver, tuple):
+            self._neo4j_driver = Neo4jDriver.from_Neo4jDriver(neo4j_driver[0], neo4j_driver[1])
         else:
-            raise ValueError(f"Unknown driver, {driver}.")
+            self._neo4j_driver = neo4j_driver
+        self.__verbose = verbose
+        self._default_namespace = xgt_server.get_default_namespace()
 
         self._neo4j_has_apoc = False if disable_apoc else self.__neo4j_check_for_apoc()
         if self.__verbose and self._neo4j_has_apoc:
@@ -170,18 +251,6 @@ class Neo4jConnector(object):
         result += f"Neo4j Schema nodes: {self.neo4j_nodes}\n\n"
         result += f"Neo4j Schema edges: {self.neo4j_edges}\n\n"
         return result
-
-    @property
-    def neo4j_driver(self) -> neo4j.Neo4jDriver:
-        """
-        Retrieve the Python bolt driver connected to the Neo4j database.
-
-        Returns
-        -------
-        neo4j.Neo4jDriver
-          The Python bolt driver object that is connected to the Neo4j database.
-        """
-        return self._neo4j_driver
 
     @property
     def neo4j_relationship_types(self) -> list():
@@ -458,19 +527,19 @@ class Neo4jConnector(object):
             None
         """
         def xlate_result_property(attr, attr_type) -> str:
-            if self._arrow_driver is not None and (attr_type == 'datetime' or attr_type == 'date' or attr_type == 'time'):
+            if self._neo4j_driver._arrow_driver is not None and (attr_type == 'datetime' or attr_type == 'date' or attr_type == 'time'):
                 return f", toString(v.{a}) as {a}"
             return f", v.{a} AS {a}"
         # Use the count store to get totals.
         estimated_counts = 0
         for vertex in xgt_schemas['vertices']:
             q = f"MATCH (v:{vertex}) RETURN count(v)"
-            with self.__query(q) as query:
+            with self._neo4j_driver.query(q) as query:
                 for record in query.result():
                     estimated_counts += record[0]
         for edge in xgt_schemas['edges']:
             q = f"MATCH ()-[e:{edge}]->() RETURN count(e)"
-            with self.__query(q) as query:
+            with self._neo4j_driver.query(q) as query:
                 for record in query.result():
                     estimated_counts += record[0]
 
@@ -639,8 +708,9 @@ class Neo4jConnector(object):
                         key_pos = i
                         break
 
-                with self._neo4j_driver.session(database=self._neo4j_database,
-                                                default_access_mode=neo4j.WRITE_ACCESS) as session:
+                with self._neo4j_driver.bolt.session(
+                        database=self._neo4j_driver._database,
+                        default_access_mode=neo4j.WRITE_ACCESS) as session:
                     while (True):
                         try:
                             chunk = reader.read_chunk().data
@@ -686,8 +756,8 @@ class Neo4jConnector(object):
                         trg_key_pos = i
                         break
 
-                with self._neo4j_driver.session(database=self._neo4j_database,
-                                                default_access_mode=neo4j.WRITE_ACCESS) as session:
+                with self._neo4j_driver.bolt.session(database=self._neo4j_driver._database,
+                                                     default_access_mode=neo4j.WRITE_ACCESS) as session:
                     while (True):
                         try:
                             chunk = reader.read_chunk().data
@@ -706,34 +776,6 @@ class Neo4jConnector(object):
                             tx.close()
                         except StopIteration:
                             break
-
-    class py2neo_run_closure():
-        def __init__(self, connector, query):
-            self._result = connector._py2neo_driver.query(query)
-
-        def __enter__(self):
-            return self
-
-        def __exit__(self, exc_type,exc_value, exc_traceback):
-            pass
-
-        def result(self):
-            return self._result
-
-    class neo4j_run_closure():
-        def __init__(self, connector, query):
-            self._query = query
-            self._connector = connector
-
-        def __enter__(self):
-            self._session = self._connector._neo4j_driver.session(database=self._connector._neo4j_database,
-                                                                  default_access_mode=neo4j.READ_ACCESS)
-            return self
-        def __exit__(self, exc_type,exc_value, exc_traceback):
-            self._session.close()
-
-        def result(self):
-            return self._session.run(self._query)
 
     class progress_display():
         def __init__(self, total_count, bar_size = 60, prefix = "Transferring: "):
@@ -806,15 +848,9 @@ class Neo4jConnector(object):
         def get_token(self):
             return self.token
 
-    def __query(self, query, use_neo4j_always = False):
-        if not use_neo4j_always and self._py2neo_driver is not None:
-            return self.py2neo_run_closure(self, query)
-        else:
-            return self.neo4j_run_closure(self, query)
-
     def __neo4j_check_for_apoc(self):
         try:
-            with self.__query("RETURN apoc.version()") as query:
+            with self._neo4j_driver.query("RETURN apoc.version()") as query:
                 query.result()
                 return True
         except Exception as e:
@@ -823,7 +859,7 @@ class Neo4jConnector(object):
 
     def __neo4j_property_keys(self, flush_cache = True):
         if flush_cache:
-            with self.__query("CALL db.propertyKeys() YIELD propertyKey RETURN propertyKey") as query:
+            with self._neo4j_driver.query("CALL db.propertyKeys() YIELD propertyKey RETURN propertyKey") as query:
                 self._neo4j_property_keys = list([record["propertyKey"] for record in query.result()])
                 self._neo4j_property_keys.sort()
         return self._neo4j_property_keys
@@ -835,7 +871,7 @@ class Neo4jConnector(object):
                 q="CALL apoc.meta.nodeTypeProperties() YIELD nodeType, nodeLabels, propertyName, propertyTypes, mandatory RETURN *"
             else:
                 q="CALL db.schema.nodeTypeProperties() YIELD nodeType, nodeLabels, propertyName, propertyTypes, mandatory RETURN *"
-            with self.__query(q) as query:
+            with self._neo4j_driver.query(q) as query:
                 self._neo4j_node_type_properties = [{_ : record[_] for _ in fields} for record in query.result()]
         return self._neo4j_node_type_properties
 
@@ -846,7 +882,7 @@ class Neo4jConnector(object):
                 q="CALL apoc.meta.relTypeProperties() YIELD relType, propertyName, propertyTypes, mandatory RETURN *"
             else:
                 q="CALL db.schema.relTypeProperties() YIELD relType, propertyName, propertyTypes, mandatory RETURN *"
-            with self.__query(q) as query:
+            with self._neo4j_driver.query(q) as query:
                 self._neo4j_rel_type_properties = [{_ : record[_] for _ in fields} for record in query.result()]
         return self._neo4j_rel_type_properties
 
@@ -861,7 +897,7 @@ class Neo4jConnector(object):
         else:
             q="CALL db.schema.visualization() YIELD nodes, relationships RETURN *"
         # TODO(landwehrj) Can schema be done with py2neo?
-        with self.__query(q, True) as query:
+        with self._neo4j_driver.query(q, True) as query:
             for record in query.result():
                 has_multiple_relations = len(record['relationships']) > 1
                 for e in record['relationships']:
@@ -879,7 +915,7 @@ class Neo4jConnector(object):
                         # See https://github.com/neo4j/neo4j/issues/9726
                         schema_exists = False
                         q = f"MATCH (:{source_name})-[e:{e_type}]->(:{target_name}) return count(e) > 0"
-                        with self.__query(q) as query:
+                        with self._neo4j_driver.query(q) as query:
                             for result in query.result():
                                 schema_exists = result[0]
 
@@ -1049,16 +1085,16 @@ class Neo4jConnector(object):
         return arrow_conn.do_get(pf.Ticket(self._default_namespace + '__' + frame_name))
 
     def __copy_data(self, cypher_for_extract, frame, neo4j_schema, progress_bar):
-        if self._py2neo_driver is not None:
+        if self._neo4j_driver._py2neo_driver is not None:
             self.__py2neo_copy_data(cypher_for_extract, neo4j_schema, frame, progress_bar)
-        elif self._arrow_driver is not None:
+        elif self._neo4j_driver._arrow_driver is not None:
             self.__arrow_copy_data(cypher_for_extract, frame, progress_bar)
         else:
             self.__bolt_copy_data(cypher_for_extract, neo4j_schema, frame, progress_bar)
 
     def __bolt_copy_data(self, cypher_for_extract, neo4j_schema, frame, progress_bar):
-        with self._neo4j_driver.session(database=self._neo4j_database,
-                                        default_access_mode=neo4j.READ_ACCESS) as session:
+        with self._neo4j_driver.bolt.session(database=self._neo4j_driver._database,
+                                             default_access_mode=neo4j.READ_ACCESS) as session:
             schema = pa.schema([])
             # With xGT 10.1 we need to change double to float
             # so we infer the schema manually.
@@ -1112,7 +1148,7 @@ class Neo4jConnector(object):
             arrow_type = self._NEO4J_TYPE_TO_ARROW_TYPE[value[1]]
             schema = schema.append(pa.field('col' + str(i), arrow_type))
 
-        result = self._py2neo_driver.query(cypher_for_extract)
+        result = self._neo4j_driver._py2neo_driver.query(cypher_for_extract)
         data = [None] * len(result.keys())
 
         block_size = 10000
@@ -1151,12 +1187,12 @@ class Neo4jConnector(object):
         xgt_writer.close()
 
     def __arrow_copy_data(self, cypher_for_extract, frame, progress_bar):
-        ticket = self._arrow_driver.cypher(cypher_for_extract,
-                                           self._neo4j_database_arrow)
-        ready = self._arrow_driver.wait_for_job(ticket, timeout=60)
+        ticket = self._neo4j_driver._arrow_driver.cypher(cypher_for_extract,
+                                                         self._neo4j_driver._database_arrow)
+        ready = self._neo4j_driver._arrow_driver.wait_for_job(ticket, timeout=60)
         if not ready:
             raise Exception('something is wrong...did you submit a job?')
-        neo4j_reader = self._arrow_driver.stream(ticket).to_reader()
+        neo4j_reader = self._neo4j_driver._arrow_driver.stream(ticket).to_reader()
         xgt_writer = self.__arrow_writer(frame, neo4j_reader.schema)
         # move data from Neo4j to xGT in chunks
         while (True):


### PR DESCRIPTION
This separates out the driver from the connector and also allows for the user to pass in the neo4j.Neo4jDriver to the connector instead of the driver we provide.