### PR TITLE
Switch deprecated functions for newer versions to fix warnings.

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+2.0.0 (06-14-2023)
+------------------
+
+Changed
+^^^^^^^
+  - Require xGT 1.14.
+
+Fixed
+^^^^^
+  - Warnings about deprecated functions.
+
 1.7.0 (02-22-2023)
 ------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -41,7 +41,7 @@ copyright = '2022-2023, Trovares, Inc.'
 author = 'trovares.com'
 
 # The full version, including alpha/beta/rc tags
-release = '1.7.0'
+release = '2.0.0'
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/requirements.rst
+++ b/docs/source/requirements.rst
@@ -23,9 +23,9 @@ Requirements
 ============
 
 * `Neo4j Python package <https://pypi.org/project/neo4j/>`_ >= 4.4.1
-* `xGT Python package <https://pypi.org/project/xgt/>`_ >= 1.10.0
+* `xGT Python package <https://pypi.org/project/xgt/>`_ >= 1.14.0
 * `Pyarrow package <https://pypi.org/project/pyarrow/>`_ >= 7.0.0
-* `Trovares xGT <https://www.trovares.com>`_ >= 1.10.0
+* `Trovares xGT <https://www.trovares.com>`_ >= 1.14.0
 
 The Python packages can be installed through pip:
 

--- a/examples/odbc/match_oracle.py
+++ b/examples/odbc/match_oracle.py
@@ -92,7 +92,7 @@ print('\n')
 c.transfer_query_to_xgt('SELECT * FROM "Knows"', mapping=('XgtKnows', ('XgtPerson', 'XgtPerson', 'Person1', 'Person2')), easy_edges=True)
 
 print('The follow table data was transferred for the Edges with query, SELECT * FROM "Knows":')
-print(xgt_server.get_edge_frame('XgtKnows').get_data())
+print(xgt_server.get_frame('XgtKnows').get_data())
 print('\n')
 
 xgt_server.drop_frame('XgtKnows')
@@ -103,7 +103,7 @@ xgt_server.drop_frame('XgtPerson')
 c.transfer_query_to_xgt('SELECT "Relationship", "Person1", "Person2" FROM "Knows"', mapping=('XgtKnows', ('XgtPerson', 'XgtPerson', 'Person1', 'Person2')), easy_edges=True)
 
 print('The follow table data was transferred for the Edges with query, SELECT "Relationship", "Person1", "Person2" FROM "Knows":')
-print(xgt_server.get_edge_frame('XgtKnows').get_data())
+print(xgt_server.get_frame('XgtKnows').get_data())
 print('\n')
 
 # Look for a loop

--- a/examples/odbc/match_sap.py
+++ b/examples/odbc/match_sap.py
@@ -93,7 +93,7 @@ print('\n')
 c.transfer_query_to_xgt('SELECT * FROM Knows', mapping=('XgtKnows', ('XgtPerson', 'XgtPerson', 'Person1', 'Person2')), easy_edges=True)
 
 print('The follow table data was transferred for the Edges with query, SELECT * FROM "Knows":')
-print(xgt_server.get_edge_frame('XgtKnows').get_data())
+print(xgt_server.get_frame('XgtKnows').get_data())
 print('\n')
 
 xgt_server.drop_frame('XgtKnows')
@@ -104,7 +104,7 @@ xgt_server.drop_frame('XgtPerson')
 c.transfer_query_to_xgt('SELECT Relationship, Person1, Person2 FROM Knows', mapping=('XgtKnows', ('XgtPerson', 'XgtPerson', 'Person1', 'Person2')), easy_edges=True)
 
 print('The follow table data was transferred for the Edges with query, SELECT Relationship, Person1, Person2 FROM Knows:')
-print(xgt_server.get_edge_frame('XgtKnows').get_data())
+print(xgt_server.get_frame('XgtKnows').get_data())
 print('\n')
 
 # Look for a loop

--- a/jupyter/neo4j/hello_world.ipynb
+++ b/jupyter/neo4j/hello_world.ipynb
@@ -246,7 +246,7 @@
     "query = \"match(a)-->()-->()-->(a) return a.name into results\"\n",
     "\n",
     "xgt_server.run_job(query)\n",
-    "xgt_server.get_table_frame(\"results\").save(\"results.csv\")\n",
+    "xgt_server.get_frame(\"results\").save(\"results.csv\")\n",
     "xgt_server.drop_frame(\"results\")"
    ]
   },
@@ -351,8 +351,8 @@
    "source": [
     "import networkx as nx\n",
     "\n",
-    "edge_data = [tuple(x) for x in xgt_server.get_edge_frame(\"Knows\").get_data()]\n",
-    "vertex_data = xgt_server.get_vertex_frame(\"Person\").get_data()\n",
+    "edge_data = [tuple(x) for x in xgt_server.get_frame(\"Knows\").get_data()]\n",
+    "vertex_data = xgt_server.get_frame(\"Person\").get_data()\n",
     "\n",
     "dg = nx.DiGraph()\n",
     "\n",

--- a/jupyter/odbc/hello_world.ipynb
+++ b/jupyter/odbc/hello_world.ipynb
@@ -151,7 +151,7 @@
     "query = \"match(a)-->()-->()-->(a) return a.name into results\"\n",
     "\n",
     "xgt_server.run_job(query)\n",
-    "xgt_server.get_table_frame(\"results\").save(\"results.csv\")\n",
+    "xgt_server.get_frame(\"results\").save(\"results.csv\")\n",
     "xgt_server.drop_frame(\"results\")"
    ]
   },
@@ -256,8 +256,8 @@
    "source": [
     "import networkx as nx\n",
     "\n",
-    "edge_data = [tuple(x) for x in xgt_server.get_edge_frame(\"Knows\").get_data()]\n",
-    "vertex_data = xgt_server.get_vertex_frame(\"Person\").get_data()\n",
+    "edge_data = [tuple(x) for x in xgt_server.get_frame(\"Knows\").get_data()]\n",
+    "vertex_data = xgt_server.get_frame(\"Person\").get_data()\n",
     "\n",
     "dg = nx.DiGraph()\n",
     "\n",

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@
 
 [metadata]
 name = trovares_connector
-version = 1.7.0
+version = 2.0.0
 author = Trovares, Inc.
 author_email = support@trovares.com
 description = Connecting the Trovares xGT graph analytics engine to other applications.
@@ -54,7 +54,7 @@ packages = find:
 python_requires = >=3.7
 install_requires =
     neo4j>=4.4.1
-    xgt>=1.10.1
+    xgt>=1.14.0
     pyarrow>=7.0.0
     antlr4-python3-runtime>=4.10
 

--- a/src/trovares_connector/neo4j_connector/neo4j_connector.py
+++ b/src/trovares_connector/neo4j_connector/neo4j_connector.py
@@ -595,7 +595,7 @@ class Neo4jConnector(object):
             vname = schema['xgt_name']
             if append:
                 try:
-                    frame = self._xgt_server.get_vertex_frame(vname)
+                    frame = self._xgt_server.get_frame(vname)
                     if frame.schema != table_schema:
                         raise ValueError(
                             f"Vertex Frame {vname} has a schema {frame.schema}"
@@ -817,8 +817,8 @@ class Neo4jConnector(object):
         if namespace == None:
             namespace = self._default_namespace
         if vertices == None and edges == None:
-            vertices = [frame.name for frame in xgt_server.get_vertex_frames(namespace=namespace)]
-            edges = [frame.name for frame in xgt_server.get_edge_frames(namespace=namespace)]
+            vertices = [frame.name for frame in xgt_server.get_frames(namespace=namespace, frame_type='vertex')]
+            edges = [frame.name for frame in xgt_server.get_frames(namespace=namespace, frame_type='edge')]
             namespace = None
         elif vertices == None:
             vertices = []
@@ -828,7 +828,7 @@ class Neo4jConnector(object):
         id_neo4j_map = { }
 
         for edge in edges:
-            edge_frame = xgt_server.get_edge_frame(edge)
+            edge_frame = xgt_server.get_frame(edge)
             vertices.append(edge_frame.source_name)
             vertices.append(edge_frame.target_name)
 
@@ -875,16 +875,16 @@ class Neo4jConnector(object):
             if vertex in count_map:
                 continue
             count_map[vertex] = True
-            estimated_counts += xgt_server.get_vertex_frame(vertex).num_rows
+            estimated_counts += xgt_server.get_frame(vertex).num_rows
         for edge in edges:
-            estimated_counts += xgt_server.get_edge_frame(edge).num_rows
+            estimated_counts += xgt_server.get_frame(edge).num_rows
 
         with ProgressDisplay(estimated_counts) as progress_bar:
             for vertex in vertices:
                 if vertex in id_neo4j_map:
                     continue
                 id_neo4j_map[vertex] = { }
-                vertex_frame = xgt_server.get_vertex_frame(vertex)
+                vertex_frame = xgt_server.get_frame(vertex)
                 create_string = 'create (a:' + vertex + '{{{0}}}) return ID(a)'
 
                 schema = vertex_frame.schema
@@ -922,11 +922,11 @@ class Neo4jConnector(object):
                             break
 
             for edge in edges:
-                edge_frame = xgt_server.get_edge_frame(edge)
+                edge_frame = xgt_server.get_frame(edge)
                 source = edge_frame.source_name
                 target = edge_frame.target_name
-                source_frame = xgt_server.get_vertex_frame(source)
-                target_frame = xgt_server.get_vertex_frame(target)
+                source_frame = xgt_server.get_frame(source)
+                target_frame = xgt_server.get_frame(target)
                 source_map = id_neo4j_map[source]
                 target_map = id_neo4j_map[target]
                 create_string = 'match (a:' + source + '), (b:' + target + ') where ID(a) = {0} and ID(b) = {1} create (a)-[:' + edge + '{{{2}}}]->(b)'

--- a/src/trovares_connector/odbc.py
+++ b/src/trovares_connector/odbc.py
@@ -505,9 +505,9 @@ class ODBCConnector(object):
         if namespace == None:
             namespace = self._default_namespace
         if vertices == None and edges == None and tables == None:
-            vertices = [(frame.name, frame.name) for frame in xgt_server.get_vertex_frames(namespace=namespace)]
-            edges = [(frame.name, frame.name) for frame in xgt_server.get_edge_frames(namespace=namespace)]
-            tables = [(frame.name, frame.name) for frame in xgt_server.get_table_frames(namespace=namespace)]
+            vertices = [(frame.name, frame.name) for frame in xgt_server.get_frames(namespace=namespace, frame_type='vertex')]
+            edges = [(frame.name, frame.name) for frame in xgt_server.get_frames(namespace=namespace, frame_type='edge')]
+            tables = [(frame.name, frame.name) for frame in xgt_server.get_frames(namespace=namespace, frame_type='table')]
             namespace = None
         if vertices == None:
             vertices = []
@@ -539,11 +539,11 @@ class ODBCConnector(object):
         estimate = 0
 
         for vertex in final_vertices:
-            estimate += xgt_server.get_vertex_frame(vertex[0]).num_rows
+            estimate += xgt_server.get_frame(vertex[0]).num_rows
         for edge in final_edges:
-            estimate += xgt_server.get_edge_frame(edge[0]).num_rows
+            estimate += xgt_server.get_frame(edge[0]).num_rows
         for table in final_tables:
-            estimate += xgt_server.get_table_frame(table[0]).num_rows
+            estimate += xgt_server.get_frame(table[0]).num_rows
 
         with ProgressDisplay(estimate) as progress_bar:
             for table in final_vertices + final_edges + final_tables:

--- a/test/test_neo4j_connector.py
+++ b/test/test_neo4j_connector.py
@@ -234,7 +234,7 @@ class TestXgtNeo4jConnector(unittest.TestCase):
       attributes = {_:t for _, t in table_schema}
       print(f"\nAttributes: {attributes}")
     c.copy_data_to_xgt(xgt_schema)
-    node_frame = self.xgt.get_vertex_frame('Node')
+    node_frame = self.xgt.get_frame('Node')
     assert node_frame.num_rows == 1
 
   def test_transfer_node_working_types_bolt(self):
@@ -247,7 +247,7 @@ class TestXgtNeo4jConnector(unittest.TestCase):
       attributes = {_:t for _, *t  in table_schema}
       print(f"\nAttributes: {attributes}")
     c.copy_data_to_xgt(xgt_schema)
-    node_frame = self.xgt.get_vertex_frame('Node')
+    node_frame = self.xgt.get_frame('Node')
     assert node_frame.num_rows == 3
     print(node_frame.get_data())
 
@@ -255,14 +255,14 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     self._populate_node_working_types_bolt()
     c = self.conn
     c.transfer_to_xgt(vertices=['Node'])
-    node_frame = self.xgt.get_vertex_frame('Node')
+    node_frame = self.xgt.get_frame('Node')
     assert node_frame.num_rows == 3
     expected = [row[1:] for row in node_frame.get_data()]
     self.neo4j_driver.query("MATCH (n) DETACH DELETE n").finalize()
     c.transfer_to_neo4j(vertices=['Node'])
     self.xgt.drop_frame("Node")
     c.transfer_to_xgt(vertices=['Node'])
-    node_frame = self.xgt.get_vertex_frame('Node')
+    node_frame = self.xgt.get_frame('Node')
     assert node_frame.num_rows == 3
     result = [row[1:] for row in node_frame.get_data()]
     # The column ordering can change when uploading to neo4j
@@ -285,8 +285,8 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     self._populate_relationship_working_types_bolt()
     c = self.conn
     c.transfer_to_xgt(edges=['Relationship'])
-    node_frame = self.xgt.get_vertex_frame('Node')
-    edge_frame = self.xgt.get_edge_frame('Relationship')
+    node_frame = self.xgt.get_frame('Node')
+    edge_frame = self.xgt.get_frame('Relationship')
     assert edge_frame.num_rows == 3
     node_expected = [row[1:] for row in node_frame.get_data()]
     edge_expected = [row[2:] for row in edge_frame.get_data()]
@@ -295,8 +295,8 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     self.xgt.drop_frame("Relationship")
     self.xgt.drop_frame("Node")
     c.transfer_to_xgt(edges=['Relationship'])
-    node_frame = self.xgt.get_vertex_frame('Node')
-    edge_frame = self.xgt.get_edge_frame('Relationship')
+    node_frame = self.xgt.get_frame('Node')
+    edge_frame = self.xgt.get_frame('Relationship')
     assert edge_frame.num_rows == 3
     node_result = [row[1:] for row in node_frame.get_data()]
     edge_result = [row[2:] for row in edge_frame.get_data()]
@@ -323,7 +323,7 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     xgt_schema = c.get_xgt_schemas(vertices=['Node'], edges=['Relationship'])
     c.create_xgt_schemas(xgt_schema)
     c.copy_data_to_xgt(xgt_schema)
-    edge_frame = self.xgt.get_edge_frame('Relationship')
+    edge_frame = self.xgt.get_frame('Relationship')
     assert edge_frame.num_rows == 3
     print(edge_frame.get_data())
     self.xgt.drop_frame("Relationship")
@@ -334,8 +334,8 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     xgt_schema = c.get_xgt_schemas(vertices=[('Node', 'n')], edges=[('Relationship', 'r')])
     c.create_xgt_schemas(xgt_schema)
     c.copy_data_to_xgt(xgt_schema)
-    node_frame = self.xgt.get_vertex_frame('n')
-    edge_frame = self.xgt.get_edge_frame('r')
+    node_frame = self.xgt.get_frame('n')
+    edge_frame = self.xgt.get_frame('r')
     assert node_frame.num_rows == 6
     assert edge_frame.num_rows == 3
     print(edge_frame.get_data())
@@ -347,8 +347,8 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     xgt_schema = c.get_xgt_schemas(edges=['Relationship'])
     c.create_xgt_schemas(xgt_schema)
     c.copy_data_to_xgt(xgt_schema)
-    node_frame = self.xgt.get_vertex_frame('Node')
-    edge_frame = self.xgt.get_edge_frame('Relationship')
+    node_frame = self.xgt.get_frame('Node')
+    edge_frame = self.xgt.get_frame('Relationship')
     assert node_frame.num_rows == 6
     assert edge_frame.num_rows == 3
     assert node_frame.get_data(length=1)[0][1] == 1
@@ -361,8 +361,8 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     xgt_schema = c.get_xgt_schemas(edges=['Relationship'], import_edge_nodes=False)
     c.create_xgt_schemas(xgt_schema, append=True)
     c.copy_data_to_xgt(xgt_schema)
-    node_frame = self.xgt.get_vertex_frame('Node')
-    edge_frame = self.xgt.get_edge_frame('Relationship')
+    node_frame = self.xgt.get_frame('Node')
+    edge_frame = self.xgt.get_frame('Relationship')
     assert node_frame.num_rows == 6
     assert edge_frame.num_rows == 3
     assert node_frame.get_data(length=1)[0][1] == 1
@@ -374,8 +374,8 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     xgt_schema = c.get_xgt_schemas()
     c.create_xgt_schemas(xgt_schema)
     c.copy_data_to_xgt(xgt_schema)
-    node_frame = self.xgt.get_vertex_frame('Node')
-    edge_frame = self.xgt.get_edge_frame('Relationship')
+    node_frame = self.xgt.get_frame('Node')
+    edge_frame = self.xgt.get_frame('Relationship')
     assert node_frame.num_rows == 6
     assert edge_frame.num_rows == 3
     self.xgt.drop_frame("Relationship")
@@ -394,11 +394,11 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     self.neo4j_driver.query(
         'CREATE (:Node{int: 344, str: "string"})').finalize()
     c.copy_data_to_xgt(xgt_schema)
-    node_frame = self.xgt.get_vertex_frame('Node')
+    node_frame = self.xgt.get_frame('Node')
     assert node_frame.num_rows == 2
 
     c.create_xgt_schemas(xgt_schema, append=False)
-    node_frame = self.xgt.get_vertex_frame('Node')
+    node_frame = self.xgt.get_frame('Node')
     assert node_frame.num_rows == 0
 
   def test_dropping(self):
@@ -409,19 +409,19 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     xgt_schema2 = c.get_xgt_schemas(vertices=['Node'])
 
     c.create_xgt_schemas(xgt_schema1)
-    self.xgt.get_vertex_frame('Node')
-    self.xgt.get_edge_frame('Relationship')
+    self.xgt.get_frame('Node')
+    self.xgt.get_frame('Relationship')
 
     c.create_xgt_schemas(xgt_schema1)
-    self.xgt.get_vertex_frame('Node')
-    self.xgt.get_edge_frame('Relationship')
+    self.xgt.get_frame('Node')
+    self.xgt.get_frame('Relationship')
 
     with self.assertRaises(xgt.XgtFrameDependencyError):
         c.create_xgt_schemas(xgt_schema2)
     c.create_xgt_schemas(xgt_schema2, force=True)
-    self.xgt.get_vertex_frame('Node')
+    self.xgt.get_frame('Node')
     with self.assertRaises(xgt.XgtNameError):
-        self.xgt.get_edge_frame('Relationship')
+        self.xgt.get_frame('Relationship')
 
   def test_multiple_node_labels_to(self):
     c = self.conn
@@ -431,9 +431,9 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     c.create_xgt_schemas(schema)
     c.copy_data_to_xgt(schema)
 
-    node_frame = self.xgt.get_edge_frame('Node1_Relationship_Node1')
+    node_frame = self.xgt.get_frame('Node1_Relationship_Node1')
     assert node_frame.num_rows == 1
-    node_frame = self.xgt.get_edge_frame('Node1_Relationship_Node2')
+    node_frame = self.xgt.get_frame('Node1_Relationship_Node2')
     assert node_frame.num_rows == 1
     self.xgt.drop_frame("Node1_Relationship_Node1")
     self.xgt.drop_frame("Node1_Relationship_Node2")
@@ -446,9 +446,9 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     c.create_xgt_schemas(schema)
     c.copy_data_to_xgt(schema)
 
-    node_frame = self.xgt.get_edge_frame('Node1_Relationship_Node1')
+    node_frame = self.xgt.get_frame('Node1_Relationship_Node1')
     assert node_frame.num_rows == 1
-    node_frame = self.xgt.get_edge_frame('Node2_Relationship_Node1')
+    node_frame = self.xgt.get_frame('Node2_Relationship_Node1')
     assert node_frame.num_rows == 1
     self.xgt.drop_frame("Node1_Relationship_Node1")
     self.xgt.drop_frame("Node2_Relationship_Node1")
@@ -500,30 +500,30 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     c = self.conn
     self.neo4j_driver.query('CREATE ()').finalize()
     c.transfer_to_xgt(vertices=[''])
-    node_frame = self.xgt.get_vertex_frame('unlabeled')
+    node_frame = self.xgt.get_frame('unlabeled')
     assert node_frame.num_rows == 1
 
   def test_map_empty_labels(self):
     c = self.conn
     self.neo4j_driver.query('CREATE ()').finalize()
     c.transfer_to_xgt(vertices=[('', 'custom_name')])
-    node_frame = self.xgt.get_vertex_frame('custom_name')
+    node_frame = self.xgt.get_frame('custom_name')
     assert node_frame.num_rows == 1
     with self.assertRaises(xgt.XgtNameError):
-        node_frame = self.xgt.get_vertex_frame('unlabeled')
+        node_frame = self.xgt.get_frame('unlabeled')
 
   def test_empty_labels_schema(self):
     c = self.conn
     self.neo4j_driver.query('CREATE ({int:2})').finalize()
     c.transfer_to_xgt(vertices=[''])
-    node_frame = self.xgt.get_vertex_frame('unlabeled')
+    node_frame = self.xgt.get_frame('unlabeled')
     res = self.xgt.run_job('match (v) return v.int')
     assert node_frame.num_rows == 1
     assert res.get_data()[0][0] == 2
     self.neo4j_driver.query("MATCH (n) DETACH DELETE n").finalize()
     self.neo4j_driver.query('CREATE ({str:"bbb"})').finalize()
     c.transfer_to_xgt(vertices=[''])
-    node_frame = self.xgt.get_vertex_frame('unlabeled')
+    node_frame = self.xgt.get_frame('unlabeled')
     res = self.xgt.run_job('match (v) return v.str')
     assert node_frame.num_rows == 1
     assert res.get_data()[0][0] == "bbb"
@@ -533,15 +533,15 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     self.neo4j_driver.query(
         'CREATE ()-[:e1]->(), (:Node)-[:e2]->(), ()-[:e3]->(:Node)').finalize()
     c.transfer_to_xgt(edges=['e1', 'e2', 'e3'])
-    node_frame = self.xgt.get_edge_frame('e1')
+    node_frame = self.xgt.get_frame('e1')
     assert node_frame.num_rows == 1
-    node_frame = self.xgt.get_edge_frame('e2')
+    node_frame = self.xgt.get_frame('e2')
     assert node_frame.num_rows == 1
-    node_frame = self.xgt.get_edge_frame('e3')
+    node_frame = self.xgt.get_frame('e3')
     assert node_frame.num_rows == 1
-    node_frame = self.xgt.get_vertex_frame('unlabeled')
+    node_frame = self.xgt.get_frame('unlabeled')
     assert node_frame.num_rows == 4
-    node_frame = self.xgt.get_vertex_frame('Node')
+    node_frame = self.xgt.get_frame('Node')
     assert node_frame.num_rows == 2
 
   def test_edge_empty_labels_schema(self):
@@ -549,21 +549,21 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     self.neo4j_driver.query(
         'CREATE ()-[:e1]->({int:1}), (:Node)-[:e2]->({str:"aaa"}), ({bool:True})-[:e3]->(:Node)').finalize()
     c.transfer_to_xgt(edges=['e1', 'e2', 'e3'])
-    node_frame = self.xgt.get_edge_frame('e1')
+    node_frame = self.xgt.get_frame('e1')
     res = self.xgt.run_job('match ()-[:e1]->(v) return v.int')
     assert node_frame.num_rows == 1
     assert res.get_data()[0][0] == 1
-    node_frame = self.xgt.get_edge_frame('e2')
+    node_frame = self.xgt.get_frame('e2')
     res = self.xgt.run_job('match ()-[:e2]->(v) return v.str')
     assert node_frame.num_rows == 1
     assert res.get_data()[0][0] == "aaa"
-    node_frame = self.xgt.get_edge_frame('e3')
+    node_frame = self.xgt.get_frame('e3')
     res = self.xgt.run_job('match (v)-[:e3]->() return v.bool')
     assert node_frame.num_rows == 1
     assert res.get_data()[0][0] == True
-    node_frame = self.xgt.get_vertex_frame('unlabeled')
+    node_frame = self.xgt.get_frame('unlabeled')
     assert node_frame.num_rows == 4
-    node_frame = self.xgt.get_vertex_frame('Node')
+    node_frame = self.xgt.get_frame('Node')
     assert node_frame.num_rows == 2
 
   def test_map_edge_empty_labels(self):
@@ -571,20 +571,20 @@ class TestXgtNeo4jConnector(unittest.TestCase):
     self.neo4j_driver.query(
         'CREATE ()-[:e1]->(), (:Node)-[:e2]->(), ()-[:e3]->(:Node)').finalize()
     c.transfer_to_xgt(vertices=[('', 'custom_empty'), ('Node', 'custom_Node')], edges=[('e1', 'edge1'), ('e2', 'edge2'), 'e3'])
-    node_frame = self.xgt.get_edge_frame('edge1')
+    node_frame = self.xgt.get_frame('edge1')
     assert node_frame.num_rows == 1
-    node_frame = self.xgt.get_edge_frame('edge2')
+    node_frame = self.xgt.get_frame('edge2')
     assert node_frame.num_rows == 1
-    node_frame = self.xgt.get_edge_frame('e3')
+    node_frame = self.xgt.get_frame('e3')
     assert node_frame.num_rows == 1
-    node_frame = self.xgt.get_vertex_frame('custom_empty')
+    node_frame = self.xgt.get_frame('custom_empty')
     assert node_frame.num_rows == 4
-    node_frame = self.xgt.get_vertex_frame('custom_Node')
+    node_frame = self.xgt.get_frame('custom_Node')
     assert node_frame.num_rows == 2
     with self.assertRaises(xgt.XgtNameError):
-        node_frame = self.xgt.get_vertex_frame('unlabeled')
+        node_frame = self.xgt.get_frame('unlabeled')
     with self.assertRaises(xgt.XgtNameError):
-        node_frame = self.xgt.get_vertex_frame('Node')
+        node_frame = self.xgt.get_frame('Node')
 
   def test_edge_empty_labels_schema_no_implicit(self):
     c = self.conn
@@ -592,21 +592,21 @@ class TestXgtNeo4jConnector(unittest.TestCase):
         'CREATE ()-[:e1]->({int:1}), (:Node)-[:e2]->({str:"aaa"}), ({bool:True})-[:e3]->(:Node)').finalize()
     c.transfer_to_xgt(vertices=['', 'Node'])
     c.transfer_to_xgt(edges=['e1', 'e2', 'e3'], append=True, import_edge_nodes=False)
-    node_frame = self.xgt.get_edge_frame('e1')
+    node_frame = self.xgt.get_frame('e1')
     res = self.xgt.run_job('match ()-[:e1]->(v) return v.int')
     assert node_frame.num_rows == 1
     assert res.get_data()[0][0] == 1
-    node_frame = self.xgt.get_edge_frame('e2')
+    node_frame = self.xgt.get_frame('e2')
     res = self.xgt.run_job('match ()-[:e2]->(v) return v.str')
     assert node_frame.num_rows == 1
     assert res.get_data()[0][0] == "aaa"
-    node_frame = self.xgt.get_edge_frame('e3')
+    node_frame = self.xgt.get_frame('e3')
     res = self.xgt.run_job('match (v)-[:e3]->() return v.bool')
     assert node_frame.num_rows == 1
     assert res.get_data()[0][0] == True
-    node_frame = self.xgt.get_vertex_frame('unlabeled')
+    node_frame = self.xgt.get_frame('unlabeled')
     assert node_frame.num_rows == 4
-    node_frame = self.xgt.get_vertex_frame('Node')
+    node_frame = self.xgt.get_frame('Node')
     assert node_frame.num_rows == 2
 
   def test_query_translator_loop_data(self):

--- a/test/test_odbc_connector.py
+++ b/test/test_odbc_connector.py
@@ -74,8 +74,8 @@ class TestXgtODBCConnector(unittest.TestCase):
     self.odbc_driver.commit()
 
     self.conn.transfer_to_xgt(tables = ['test'])
-    assert self.xgt.get_table_frame('test').num_rows == 2
-    print(self.xgt.get_table_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 2
+    print(self.xgt.get_frame('test').get_data())
 
   def test_rename(self):
     cursor = self.odbc_driver.cursor()
@@ -84,12 +84,12 @@ class TestXgtODBCConnector(unittest.TestCase):
     self.odbc_driver.commit()
 
     self.conn.transfer_to_xgt(tables = [('test','test1')])
-    assert self.xgt.get_table_frame('test1').num_rows == 1
-    print(self.xgt.get_table_frame('test1').get_data())
+    assert self.xgt.get_frame('test1').num_rows == 1
+    print(self.xgt.get_frame('test1').get_data())
 
     self.conn.transfer_to_xgt(tables = [('test', {'frame' : 'test2'})])
-    assert self.xgt.get_table_frame('test2').num_rows == 1
-    print(self.xgt.get_table_frame('test2').get_data())
+    assert self.xgt.get_frame('test2').num_rows == 1
+    print(self.xgt.get_frame('test2').get_data())
 
   def test_vertex(self):
     cursor = self.odbc_driver.cursor()
@@ -99,24 +99,24 @@ class TestXgtODBCConnector(unittest.TestCase):
     self.odbc_driver.commit()
 
     self.conn.transfer_to_xgt(tables = [('test', (0,))])
-    assert self.xgt.get_vertex_frame('test').num_rows == 2
-    print(self.xgt.get_vertex_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 2
+    print(self.xgt.get_frame('test').get_data())
 
     self.conn.transfer_to_xgt(tables = [('test','test1', (0,))])
-    assert self.xgt.get_vertex_frame('test1').num_rows == 2
-    print(self.xgt.get_vertex_frame('test1').get_data())
+    assert self.xgt.get_frame('test1').num_rows == 2
+    print(self.xgt.get_frame('test1').get_data())
 
     self.conn.transfer_to_xgt(tables = [('test','test2', ('Value1',))])
-    assert self.xgt.get_vertex_frame('test2').num_rows == 2
-    print(self.xgt.get_vertex_frame('test2').get_data())
+    assert self.xgt.get_frame('test2').num_rows == 2
+    print(self.xgt.get_frame('test2').get_data())
 
     self.conn.transfer_to_xgt(tables = [('test', {'frame' : 'test3', 'key' : 0 } )])
-    assert self.xgt.get_vertex_frame('test3').num_rows == 2
-    print(self.xgt.get_vertex_frame('test3').get_data())
+    assert self.xgt.get_frame('test3').num_rows == 2
+    print(self.xgt.get_frame('test3').get_data())
 
     self.conn.transfer_to_xgt(tables = [('test', {'frame' : 'test4', 'key' : 'Value1' } )])
-    assert self.xgt.get_vertex_frame('test4').num_rows == 2
-    print(self.xgt.get_vertex_frame('test4').get_data())
+    assert self.xgt.get_frame('test4').num_rows == 2
+    print(self.xgt.get_frame('test4').get_data())
 
   def test_edge(self):
     cursor = self.odbc_driver.cursor()
@@ -126,24 +126,24 @@ class TestXgtODBCConnector(unittest.TestCase):
     self.odbc_driver.commit()
 
     self.conn.transfer_to_xgt(tables = [('test', ('Vertex', 'Vertex', 0, 1))], easy_edges=True)
-    assert self.xgt.get_edge_frame('test').num_rows == 2
-    print(self.xgt.get_edge_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 2
+    print(self.xgt.get_frame('test').get_data())
 
     self.conn.transfer_to_xgt(tables = [('test','test1', ('Vertex', 'Vertex', 0, 1))])
-    assert self.xgt.get_edge_frame('test1').num_rows == 2
-    print(self.xgt.get_edge_frame('test1').get_data())
+    assert self.xgt.get_frame('test1').num_rows == 2
+    print(self.xgt.get_frame('test1').get_data())
 
     self.conn.transfer_to_xgt(tables = [('test', 'Vertex1', (0,)), ('test','test2', ('Vertex1', 'Vertex1', 'Value1', 'Value2'))])
-    assert self.xgt.get_edge_frame('test2').num_rows == 2
-    print(self.xgt.get_edge_frame('test2').get_data())
+    assert self.xgt.get_frame('test2').num_rows == 2
+    print(self.xgt.get_frame('test2').get_data())
 
     self.conn.transfer_to_xgt(tables = [('test', {'frame' : 'test3', 'source' : 'Vertex', 'target' : 'Vertex', 'source_key' : 0, 'target_key' : 1 } )])
-    assert self.xgt.get_edge_frame('test3').num_rows == 2
-    print(self.xgt.get_edge_frame('test3').get_data())
+    assert self.xgt.get_frame('test3').num_rows == 2
+    print(self.xgt.get_frame('test3').get_data())
 
     self.conn.transfer_to_xgt(tables = [('test', {'frame' : 'test4', 'source' : 'Vertex', 'target' : 'Vertex', 'source_key' : 'Value1', 'target_key' : 'Value2' } )])
-    assert self.xgt.get_edge_frame('test4').num_rows == 2
-    print(self.xgt.get_edge_frame('test4').get_data())
+    assert self.xgt.get_frame('test4').num_rows == 2
+    print(self.xgt.get_frame('test4').get_data())
 
   def test_append(self):
     cursor = self.odbc_driver.cursor()
@@ -152,16 +152,16 @@ class TestXgtODBCConnector(unittest.TestCase):
     self.odbc_driver.commit()
 
     self.conn.transfer_to_xgt(tables = [('test', ('Vertex', 'Vertex', 0, 1))], easy_edges=True)
-    assert self.xgt.get_edge_frame('test').num_rows == 1
-    print(self.xgt.get_edge_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 1
+    print(self.xgt.get_frame('test').get_data())
 
     cursor.execute("DROP TABLE IF EXISTS test")
     cursor.execute("CREATE TABLE test (Value1 INT, Value2 INT, Value3 varchar(255))")
     cursor.execute("INSERT INTO test VALUES (1, 0, 'adios')")
     self.odbc_driver.commit()
     self.conn.transfer_to_xgt(tables = [('test', ('Vertex', 'Vertex', 0, 1))], append=True)
-    assert self.xgt.get_edge_frame('test').num_rows == 2
-    print(self.xgt.get_edge_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 2
+    print(self.xgt.get_frame('test').get_data())
 
   def test_dropping(self):
     c = self.conn
@@ -176,26 +176,26 @@ class TestXgtODBCConnector(unittest.TestCase):
     xgt_schema2 = self.conn.get_xgt_schemas(tables = [('Node', (0,))])
 
     c.create_xgt_schemas(xgt_schema1)
-    self.xgt.get_vertex_frame('Node')
-    self.xgt.get_edge_frame('Relationship')
+    self.xgt.get_frame('Node')
+    self.xgt.get_frame('Relationship')
 
     c.create_xgt_schemas(xgt_schema1)
-    self.xgt.get_vertex_frame('Node')
-    self.xgt.get_edge_frame('Relationship')
+    self.xgt.get_frame('Node')
+    self.xgt.get_frame('Relationship')
 
     with self.assertRaises(xgt.XgtFrameDependencyError):
         c.create_xgt_schemas(xgt_schema2)
     c.create_xgt_schemas(xgt_schema2, force = True)
-    self.xgt.get_vertex_frame('Node')
+    self.xgt.get_frame('Node')
     with self.assertRaises(xgt.XgtNameError):
-        self.xgt.get_edge_frame('Relationship')
+        self.xgt.get_frame('Relationship')
 
   def test_transfer_no_data(self):
     c = self.conn
     cursor = self.odbc_driver.cursor()
     cursor.execute("CREATE TABLE Node (id INT)")
     self.conn.transfer_to_xgt(tables = [('Node', (0,))])
-    assert self.xgt.get_vertex_frame('Node').num_rows == 0
+    assert self.xgt.get_frame('Node').num_rows == 0
 
   def test_transfer_to_odbc(self):
     cursor = self.odbc_driver.cursor()
@@ -213,8 +213,8 @@ class TestXgtODBCConnector(unittest.TestCase):
     cursor.execute(create_statement)
     self.conn.transfer_to_odbc(tables = ['test'])
     self.conn.transfer_to_xgt(tables = ['test'])
-    assert self.xgt.get_table_frame('test').num_rows == 2
-    print(self.xgt.get_table_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 2
+    print(self.xgt.get_frame('test').get_data())
 
   def test_transfer_to_odbc_rename(self):
     cursor = self.odbc_driver.cursor()
@@ -231,8 +231,8 @@ class TestXgtODBCConnector(unittest.TestCase):
     cursor.execute(create_statement)
     self.conn.transfer_to_odbc(tables = [('test1', 'test')])
     self.conn.transfer_to_xgt(tables = ['test'])
-    assert self.xgt.get_table_frame('test').num_rows == 1
-    print(self.xgt.get_table_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 1
+    print(self.xgt.get_frame('test').get_data())
 
   def test_transfer_to_odbc_vertex(self):
     cursor = self.odbc_driver.cursor()
@@ -249,8 +249,8 @@ class TestXgtODBCConnector(unittest.TestCase):
     cursor.execute(create_statement)
     self.conn.transfer_to_odbc(vertices = ['test'])
     self.conn.transfer_to_xgt(tables = [('test', (0,))])
-    assert self.xgt.get_vertex_frame('test').num_rows == 1
-    print(self.xgt.get_vertex_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 1
+    print(self.xgt.get_frame('test').get_data())
 
   def test_transfer_to_odbc_vertex_rename(self):
     cursor = self.odbc_driver.cursor()
@@ -267,8 +267,8 @@ class TestXgtODBCConnector(unittest.TestCase):
     cursor.execute(create_statement)
     self.conn.transfer_to_odbc(vertices = [('test1', 'test')])
     self.conn.transfer_to_xgt(tables = [('test', (0,))])
-    assert self.xgt.get_vertex_frame('test').num_rows == 1
-    print(self.xgt.get_vertex_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 1
+    print(self.xgt.get_frame('test').get_data())
 
   def test_transfer_to_odbc_edges(self):
     cursor = self.odbc_driver.cursor()
@@ -285,8 +285,8 @@ class TestXgtODBCConnector(unittest.TestCase):
     cursor.execute(create_statement)
     self.conn.transfer_to_odbc(edges = ['test'])
     self.conn.transfer_to_xgt(tables = [('test', ('Vertex1', 'Vertex2', 1, 2))], easy_edges = True)
-    assert self.xgt.get_edge_frame('test').num_rows == 1
-    print(self.xgt.get_edge_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 1
+    print(self.xgt.get_frame('test').get_data())
 
   def test_transfer_to_odbc_edges_rename(self):
     cursor = self.odbc_driver.cursor()
@@ -303,8 +303,8 @@ class TestXgtODBCConnector(unittest.TestCase):
     cursor.execute(create_statement)
     self.conn.transfer_to_odbc(edges = [('test1', 'test')])
     self.conn.transfer_to_xgt(tables = [('test', ('Vertex1', 'Vertex2', 1, 2))], easy_edges = True, force = True)
-    assert self.xgt.get_edge_frame('test').num_rows == 1
-    print(self.xgt.get_edge_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 1
+    print(self.xgt.get_frame('test').get_data())
 
   def test_transfer_query(self):
     cursor = self.odbc_driver.cursor()
@@ -317,8 +317,8 @@ class TestXgtODBCConnector(unittest.TestCase):
     self.odbc_driver.commit()
 
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = 'my_test')
-    assert self.xgt.get_table_frame('my_test').num_rows == 2
-    print(self.xgt.get_table_frame('my_test').get_data())
+    assert self.xgt.get_frame('my_test').num_rows == 2
+    print(self.xgt.get_frame('my_test').get_data())
 
   def test_vertex_query(self):
     cursor = self.odbc_driver.cursor()
@@ -328,24 +328,24 @@ class TestXgtODBCConnector(unittest.TestCase):
     self.odbc_driver.commit()
 
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('test', (0,)))
-    assert self.xgt.get_vertex_frame('test').num_rows == 2
-    print(self.xgt.get_vertex_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 2
+    print(self.xgt.get_frame('test').get_data())
 
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('test1', (0,)))
-    assert self.xgt.get_vertex_frame('test1').num_rows == 2
-    print(self.xgt.get_vertex_frame('test1').get_data())
+    assert self.xgt.get_frame('test1').num_rows == 2
+    print(self.xgt.get_frame('test1').get_data())
 
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('test2', ('Value1',)))
-    assert self.xgt.get_vertex_frame('test2').num_rows == 2
-    print(self.xgt.get_vertex_frame('test2').get_data())
+    assert self.xgt.get_frame('test2').num_rows == 2
+    print(self.xgt.get_frame('test2').get_data())
 
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('test', {'frame' : 'test3', 'key' : 0 } ))
-    assert self.xgt.get_vertex_frame('test3').num_rows == 2
-    print(self.xgt.get_vertex_frame('test3').get_data())
+    assert self.xgt.get_frame('test3').num_rows == 2
+    print(self.xgt.get_frame('test3').get_data())
 
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('test', {'frame' : 'test4', 'key' : 'Value1' } ))
-    assert self.xgt.get_vertex_frame('test4').num_rows == 2
-    print(self.xgt.get_vertex_frame('test4').get_data())
+    assert self.xgt.get_frame('test4').num_rows == 2
+    print(self.xgt.get_frame('test4').get_data())
 
   def test_edge_query(self):
     cursor = self.odbc_driver.cursor()
@@ -355,25 +355,25 @@ class TestXgtODBCConnector(unittest.TestCase):
     self.odbc_driver.commit()
 
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('test', ('Vertex', 'Vertex', 0, 1)), easy_edges=True)
-    assert self.xgt.get_edge_frame('test').num_rows == 2
-    print(self.xgt.get_edge_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 2
+    print(self.xgt.get_frame('test').get_data())
 
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('test1', ('Vertex', 'Vertex', 0, 1)))
-    assert self.xgt.get_edge_frame('test1').num_rows == 2
-    print(self.xgt.get_edge_frame('test1').get_data())
+    assert self.xgt.get_frame('test1').num_rows == 2
+    print(self.xgt.get_frame('test1').get_data())
 
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('Vertex1', (0,)))
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('test', 'test2', ('Vertex1', 'Vertex1', 'Value1', 'Value2')))
-    assert self.xgt.get_edge_frame('test2').num_rows == 2
-    print(self.xgt.get_edge_frame('test2').get_data())
+    assert self.xgt.get_frame('test2').num_rows == 2
+    print(self.xgt.get_frame('test2').get_data())
 
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('test', {'frame' : 'test3', 'source' : 'Vertex', 'target' : 'Vertex', 'source_key' : 0, 'target_key' : 1 }))
-    assert self.xgt.get_edge_frame('test3').num_rows == 2
-    print(self.xgt.get_edge_frame('test3').get_data())
+    assert self.xgt.get_frame('test3').num_rows == 2
+    print(self.xgt.get_frame('test3').get_data())
 
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('test', {'frame' : 'test4', 'source' : 'Vertex', 'target' : 'Vertex', 'source_key' : 'Value1', 'target_key' : 'Value2' }))
-    assert self.xgt.get_edge_frame('test4').num_rows == 2
-    print(self.xgt.get_edge_frame('test4').get_data())
+    assert self.xgt.get_frame('test4').num_rows == 2
+    print(self.xgt.get_frame('test4').get_data())
 
   def test_append_query(self):
     cursor = self.odbc_driver.cursor()
@@ -382,20 +382,20 @@ class TestXgtODBCConnector(unittest.TestCase):
     self.odbc_driver.commit()
 
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('test', ('Vertex', 'Vertex', 0, 1)), easy_edges=True)
-    assert self.xgt.get_edge_frame('test').num_rows == 1
-    print(self.xgt.get_edge_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 1
+    print(self.xgt.get_frame('test').get_data())
 
     cursor.execute("DROP TABLE IF EXISTS test")
     cursor.execute("CREATE TABLE test (Value1 INT, Value2 INT, Value3 varchar(255))")
     cursor.execute("INSERT INTO test VALUES (1, 0, 'adios')")
     self.odbc_driver.commit()
     self.conn.transfer_query_to_xgt("SELECT * FROM test", mapping = ('test', ('Vertex', 'Vertex', 0, 1)), append=True)
-    assert self.xgt.get_edge_frame('test').num_rows == 2
-    print(self.xgt.get_edge_frame('test').get_data())
+    assert self.xgt.get_frame('test').num_rows == 2
+    print(self.xgt.get_frame('test').get_data())
 
   def test_transfer_no_data_query(self):
     c = self.conn
     cursor = self.odbc_driver.cursor()
     cursor.execute("CREATE TABLE Node (id INT)")
     self.conn.transfer_query_to_xgt("SELECT * FROM Node", mapping = ('Node', (0,)))
-    assert self.xgt.get_vertex_frame('Node').num_rows == 0
+    assert self.xgt.get_frame('Node').num_rows == 0


### PR DESCRIPTION
Require xgt 1.14.
Bump to 2.0.